### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appstore-ios.yml
+++ b/.github/workflows/appstore-ios.yml
@@ -7,6 +7,9 @@ on:
         description: 'Version (e.g. 1.6.4)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   submit:
     runs-on: macos-26


### PR DESCRIPTION
Potential fix for [https://github.com/snowzjx/RelatedWorks/security/code-scanning/2](https://github.com/snowzjx/RelatedWorks/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged and the workflow behavior is documented and stable across repos/orgs.

Best fix here: add root-level permissions just below `on` (or before `jobs`) with:

- `contents: read`

This preserves current behavior (checkout still works) while preventing implicit write scopes.

File to edit:
- `.github/workflows/appstore-ios.yml`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
