### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appstore-macos.yml
+++ b/.github/workflows/appstore-macos.yml
@@ -7,6 +7,9 @@ on:
         description: 'Version (e.g. 1.6.4)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   submit:
     runs-on: macos-26


### PR DESCRIPTION
Potential fix for [https://github.com/snowzjx/RelatedWorks/security/code-scanning/1](https://github.com/snowzjx/RelatedWorks/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/appstore-macos.yml`, immediately after the `on` section (or before `jobs`), with `contents: read`. This applies to all jobs in the workflow and preserves current functionality while preventing broader default token scopes.

Best single fix here:
- File: `.github/workflows/appstore-macos.yml`
- Change: insert
  ```yml
  permissions:
    contents: read
  ```
  before `jobs:`.

No new methods, imports, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
